### PR TITLE
implement cli args and -c to copy to clipboard

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,12 +3,16 @@
 'use strict';
 
 var gimmeSoftware = require('./stackflow.js');
+var argv = require('minimist')(process.argv.slice(2));
+var clipboard = require('copy-paste');
 
 var green = '\u001b[32m';
 var red   = '\u001b[31m';
 var reset = '\u001b[39m';
 
-var myAwesomeStack = gimmeSoftware(process.argv[2]);
+var input = typeof argv.c === 'string' ? argv.c : argv._[0];
+
+var myAwesomeStack = gimmeSoftware(input);
 
 if (!myAwesomeStack) {
   return console.error('No suitable software stacks found. Try again.');
@@ -16,3 +20,12 @@ if (!myAwesomeStack) {
 
 console.log(green + myAwesomeStack.name + reset +
   ': ' + myAwesomeStack.stack.join(', '));
+
+if (argv.c) {
+  clipboard.copy(myAwesomeStack.name + ': ' +
+    myAwesomeStack.stack.join(', '), function (error) {
+      if (error) console.log(error);
+      else console.log('Copied to clipboard!');
+    }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "homepage": "https://github.com/lxe/stackflow",
   "dependencies": {
-    "word-list": "^1.0.0"
+    "word-list": "^1.0.0",
+    "minimist": "~1.1.0",
+    "copy-paste": "~1.0.1"
   }
 }


### PR DESCRIPTION
Adds a copy to clipboard function by including `-c` in the command. Initially I wanted it to automatically copy to clipboard, but I thought that might piss people off so I added arg parsing.
